### PR TITLE
Enabled natural scrolling.

### DIFF
--- a/ubuntu-config.sh
+++ b/ubuntu-config.sh
@@ -14,4 +14,6 @@ for cmd in "${INPUTRC_COMMANDS[@]}"; do
 	fi
 done
 
+gsettings set org.gnome.settings-daemon.peripherals.touchpad natural-scroll true
+
 exit 0


### PR DESCRIPTION
Checks Natural scrolling under System Settings > Mouse & Touchpad.
