### PR TITLE
Disabled online search results in the Dash.

### DIFF
--- a/ubuntu-config.sh
+++ b/ubuntu-config.sh
@@ -15,5 +15,6 @@ for cmd in "${INPUTRC_COMMANDS[@]}"; do
 done
 
 gsettings set org.gnome.settings-daemon.peripherals.touchpad natural-scroll true
+gsettings set com.canonical.Unity.Lenses remote-content-search none
 
 exit 0


### PR DESCRIPTION
Turns off Include online search results under System Settings > Security & Privacy > Search.
